### PR TITLE
fix: use correct default value for n_kv_heads in ModelConfig

### DIFF
--- a/src/model/config.cpp
+++ b/src/model/config.cpp
@@ -32,7 +32,7 @@ void ModelConfig::from_gguf_metadata(
     intermediate_size = get_val<int>(kv, prefix + "feed_forward_length", intermediate_size);
     n_layers          = get_val<int>(kv, prefix + "block_count", n_layers);
     n_heads           = get_val<int>(kv, prefix + "attention.head_count", n_heads);
-    n_kv_heads        = get_val<int>(kv, prefix + "attention.head_count_kv", n_heads);
+    n_kv_heads        = get_val<int>(kv, prefix + "attention.head_count_kv", n_kv_heads);
     head_dim          = hidden_size / n_heads;
 
     // Context


### PR DESCRIPTION
## Description

Fix the default value used for `n_kv_heads` when reading from GGUF metadata.

## Problem

The code incorrectly used `n_heads` as the default value when reading the KV head count from metadata:

```cpp
n_kv_heads = get_val<int>(kv, prefix + "attention.head_count_kv", n_heads);
```

This caused models with Grouped Query Attention (GQA) to always use the attention head count as the KV head count, ignoring the actual value from the model configuration.

## Solution

Change the default value to `n_kv_heads` so the current member value is preserved when the metadata doesn't specify a different value:

```cpp
n_kv_heads = get_val<int>(kv, prefix + "attention.head_count_kv", n_kv_heads);
```

## Impact

- Ensures correct KV head count for models with GQA architecture
- Important for model accuracy and performance
- Low risk change - only affects the default fallback behavior

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>